### PR TITLE
Update dnssec.py to import dns.dnssec

### DIFF
--- a/dnssec_checks/dnssec.py
+++ b/dnssec_checks/dnssec.py
@@ -19,6 +19,7 @@ __author__ = 'Joint Research Centre (JRC) - E.3 Cyber and Digital Citizen\'s Sec
 
 import dns
 import dns.resolver
+import dns.dnssec
 import hashlib
 import struct
 import base64


### PR DESCRIPTION
for current versions of dnspython the dnssec tests fail because of a missing import.

importing dns.dnssec fixes the problem.

-- tested with dnspython 2.6.1